### PR TITLE
Make behaviour consistent with previous version

### DIFF
--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -419,7 +419,7 @@ module Rouge
     # an enumerator is returned.
     def lex(string, opts=nil, &b)
       warn 'The use of opts with Lexer.lex is deprecated' unless opts.nil?
-      return enum_for(:lex, string) unless block_given?
+      return enum_for(:lex, string, opts) unless block_given?
 
       if opts && opts[:continue]
         warn 'Use #continue_lex instead'

--- a/lib/rouge/lexer.rb
+++ b/lib/rouge/lexer.rb
@@ -418,12 +418,13 @@ module Rouge
     # Given a string, yield [token, chunk] pairs.  If no block is given,
     # an enumerator is returned.
     def lex(string, opts=nil, &b)
+      warn 'The use of opts with Lexer.lex is deprecated' unless opts.nil?
+      return enum_for(:lex, string) unless block_given?
+
       if opts && opts[:continue]
-        warn 'the :continue option to Formatter#lex is deprecated, use #continue_lex instead.'
+        warn 'Use #continue_lex instead'
         return continue_lex(string, &b)
       end
-
-      return enum_for(:lex, string) unless block_given?
 
       Lexer.assert_utf8!(string)
       reset!

--- a/spec/formatters/html_spec.rb
+++ b/spec/formatters/html_spec.rb
@@ -38,8 +38,12 @@ describe Rouge::Formatters::HTML do
     let(:output) { subject.format(tokens) }
 
     it 'should format token stream' do
-      assert { output == '<span class="nt">&lt;meta</span> <span class="na">name=</span><span class="s">"description"</span> <span class="na">content=</span><span class="s">"foo"</span><span class="nt">&gt;</span>
+      out, err  = capture_io do
+        assert { output == '<span class="nt">&lt;meta</span> <span class="na">name=</span><span class="s">"description"</span> <span class="na">content=</span><span class="s">"foo"</span><span class="nt">&gt;</span>
 <span class="nt">&lt;script&gt;</span><span class="nx">alert</span><span class="p">(</span><span class="dl">"</span><span class="s2">bar</span><span class="dl">"</span><span class="p">)</span><span class="nt">&lt;/script&gt;</span>' }
+      end
+
+      assert_match %r%deprecated%, err
     end
   end
 


### PR DESCRIPTION
This commit:

- makes the structure more consistent with version 3.3.0; and
- capture warning when testing. 